### PR TITLE
Update compute charts

### DIFF
--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.8.1"
+version: "0.8.2"
 appVersion: "0.3"
 description: gdi-funnel
 maintainers:

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.7.1"
+version: "0.7.2"
 appVersion: "0.2"
 description: gdi-funnel
 maintainers:

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.7.0"
+version: "0.7.1"
 appVersion: "0.2"
 description: gdi-funnel
 maintainers:

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.2"
+version: "0.3"
 appVersion: "0.1"
 description: gdi-funnel
 maintainers:

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.8.0"
+version: "0.8.1"
 appVersion: "0.3"
 description: gdi-funnel
 maintainers:

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.4"
+version: "0.5"
 appVersion: "0.1"
 description: gdi-funnel
 maintainers:

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.6"
+version: "0.6.1"
 appVersion: "0.1"
 description: gdi-funnel
 maintainers:

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.6.2"
-appVersion: "0.1"
+version: "0.7.0"
+appVersion: "0.2"
 description: gdi-funnel
 maintainers:
 - name: CERIT-SC

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,9 +1,8 @@
 apiVersion: v2
 name: gdi-funnel
-version: 0.1
-appVersion: 0.1
+version: "0.1"
+appVersion: "0.1"
 description: gdi-funnel
 maintainers:
 - name: CERIT-SC
   email: root@cerit-sc.cz
-engine: gotpl

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.3"
+version: "0.4"
 appVersion: "0.1"
 description: gdi-funnel
 maintainers:

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.6.1"
+version: "0.6.2"
 appVersion: "0.1"
 description: gdi-funnel
 maintainers:

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.7.3"
-appVersion: "0.2"
+version: "0.8.0"
+appVersion: "0.3"
 description: gdi-funnel
 maintainers:
 - name: CERIT-SC

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.5"
+version: "0.6"
 appVersion: "0.1"
 description: gdi-funnel
 maintainers:

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.1"
+version: "0.2"
 appVersion: "0.1"
 description: gdi-funnel
 maintainers:

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gdi-funnel
-version: "0.7.2"
+version: "0.7.3"
 appVersion: "0.2"
 description: gdi-funnel
 maintainers:

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -54,7 +54,7 @@ Kubernetes:
       completions: 1
       template:
         spec:
-          serviceAccountName: funnel-sa
+          serviceAccountName: {{ .Release.Name }}-sa
           restartPolicy: Never
           securityContext:
             fsGroup: 1000

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -6,7 +6,7 @@ BoltDB:
 Compute: {{ .Values.compute }}
 
 Logger:
-  Level: debug
+  Level: {{ .Values.logLevel | quote }}
 
 HTSGETStorage:
   Disabled: {{ .Values.htsget.disabled }}
@@ -19,7 +19,7 @@ Server:
   OidcAuth:
     # URL of the OIDC service configuration:
     ServiceConfigUrl: {{ .Values.oidc.url }}
-    # Client ID and secret are sent with the token introspection request 
+    # Client ID and secret are sent with the token introspection request
     # (Basic authentication):
     ClientId: {{ .Values.oidc.clientid }}
     ClientSecret: {{ .Values.oidc.clientsecret }}
@@ -30,9 +30,9 @@ Server:
   BasicAuth:
     - User: {{ .Values.basicauth.user | quote }}
       Password: {{ .Values.basicauth.password | quote }}
-  
+
   HostName: 0.0.0.0
-  
+
 RPCClient:
   User: {{ .Values.basicauth.user | quote }}
   Password: {{ .Values.basicauth.password | quote }}
@@ -42,14 +42,14 @@ Kubernetes:
   DisableReconciler: false
   ReconcileRate: 5m
   Namespace: {{ .Release.Namespace }}
-  Template: | 
+  Template: |
     apiVersion: batch/v1
     kind: Job
     metadata:
       ## DO NOT CHANGE NAME
       name: {{ print "{{.TaskId}}" }}
       namespace: {{ print "{{.Namespace}}" }}
-    spec: 
+    spec:
       backoffLimit: 0
       completions: 1
       template:
@@ -61,7 +61,7 @@ Kubernetes:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          containers: 
+          containers:
             - name: funnel-worker-{{ print "{{.TaskId}}" }}
               image: {{ .Values.image }}
               imagePullPolicy: Always
@@ -93,8 +93,8 @@ Kubernetes:
                   mountPath: /etc/config
                 - name: keys
                   mountPath: /keys
-    
-          volumes: 
+
+          volumes:
             - name: config-volume
               secret:
                 secretName: {{ .Release.Name }}-worker-config

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -57,6 +57,7 @@ Kubernetes:
           serviceAccountName: funnel-sa
           restartPolicy: Never
           securityContext:
+            fsGroup: 1000
             runAsUser: 1000
             runAsNonRoot: true
             seccompProfile:
@@ -85,6 +86,7 @@ Kubernetes:
                 capabilities:
                   drop:
                     - ALL
+                privileged: false
               volumeMounts:
                 - name: funnel-storage-{{ print "{{.TaskId}}" }}
                   mountPath: /opt/funnel/funnel-work-dir/{{ print "{{.TaskId}}" }}

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -53,6 +53,9 @@ Kubernetes:
       backoffLimit: 0
       completions: 1
       template:
+        metadata:
+            labels:
+              kubernetes.io/job.executor: "true"
         spec:
           serviceAccountName: {{ .Release.Name }}-sa
           restartPolicy: Never

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -85,9 +85,9 @@ Kubernetes:
                   memory: {{ print "{{if ne .RamGb 0.0 -}}{{printf \"%.0fG\" .RamGb}}{{else}}{{\"16M\"}}{{end}}" }}
                   ephemeral-storage: {{ print "{{if ne .DiskGb 0.0 -}}{{printf \"%.0fG\" .DiskGb}}{{else}}{{\"100M\"}}{{end}}" }}
                 limits:
-                  cpu: {{ .Values.computeResourceLimits.cpu | quote}}
-                  memory: {{ .Values.computeResourceLimits.memory | quote }}
-                  ephemeral-storage: {{ .Values.computeResourceLimits.ephemeralStorage | quote}}
+                  cpu: {{ .Values.computeResourceLimits.master.cpu | quote }}
+                  memory: {{ .Values.computeResourceLimits.master.memory | quote }}
+                  ephemeral-storage: {{ .Values.computeResourceLimits.master.ephemeralStorage | quote }}
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -86,13 +86,8 @@ Kubernetes:
             - name: funnel-worker-{{ print "{{.TaskId}}" }}
               image: {{ .Values.image }}
               imagePullPolicy: Always
-              args:
-                - "worker"
-                - "run"
-                - "--config"
-                - "/etc/config/funnel-worker-config.yml"
-                - "--taskID"
-                - {{ print "{{.TaskId}}" }}
+              command: ["/app/funnel"]
+              args: ["worker", "run", "--config", "/etc/config/funnel-worker-config.yml", "--taskID", {{ print "{{.TaskId}}" }}]
               resources:
                 requests:
                   cpu: {{ print "{{if ne .Cpus 0 -}}{{.Cpus}}{{ else }}{{\"100m\"}}{{end}}" }}

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -43,6 +43,17 @@ RPCClient:
   User: {{ .Values.basicauth.user | quote }}
   Password: {{ .Values.basicauth.password | quote }}
 
+AmazonS3:
+  Disabled: {{ .Values.awsS3.disabled }}
+  Key: {{ .Values.awsS3.key | quote }}
+  Secret: {{ .Values.awsS3.secret | quote }}
+
+GenericS3:
+  - Disabled: {{ .Values.genericS3.disabled }}
+    Endpoint: {{ .Values.genericS3.endpoint | quote }}
+    Key: {{ .Values.genericS3.key | quote }}
+    Secret: {{ .Values.genericS3.secret | quote }}
+
 Kubernetes:
   DisableJobCleanup: false
   DisableReconciler: false

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -63,8 +63,8 @@ Kubernetes:
           serviceAccountName: {{ .Release.Name }}-sa
           restartPolicy: Never
           securityContext:
-            fsGroup: 1000
-            runAsUser: 65534
+            fsGroup: {{ .Values.securityContext.master.fsGroup}}
+            runAsUser: {{ .Values.securityContext.master.runAsUser}}
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -46,8 +46,6 @@ Kubernetes:
     apiVersion: batch/v1
     kind: Job
     metadata:
-      labels:
-        "kubernetes.io/job.executor": "true"
       ## DO NOT CHANGE NAME
       name: {{ print "{{.TaskId}}" }}
       namespace: {{ print "{{.Namespace}}" }}

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -85,8 +85,9 @@ Kubernetes:
                   memory: {{ print "{{if ne .RamGb 0.0 -}}{{printf \"%.0fG\" .RamGb}}{{else}}{{\"16M\"}}{{end}}" }}
                   ephemeral-storage: {{ print "{{if ne .DiskGb 0.0 -}}{{printf \"%.0fG\" .DiskGb}}{{else}}{{\"100M\"}}{{end}}" }}
                 limits:
-                  cpu: 1000m
-                  memory: 1G
+                  cpu: {{ .Values.computeResourceLimits.cpu | quote}}
+                  memory: {{ .Values.computeResourceLimits.memory | quote }}
+                  ephemeral-storage: {{ .Values.computeResourceLimits.ephemeralStorage | quote}}
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -89,8 +89,7 @@ Kubernetes:
                 privileged: false
               volumeMounts:
                 - name: funnel-storage-{{ print "{{.TaskId}}" }}
-                  mountPath: /opt/funnel/funnel-work-dir/{{ print "{{.TaskId}}" }}
-                  subPath: {{ print "{{.TaskId}}" }}
+                  mountPath: /opt/funnel/funnel-work-dir
                 - name: config-volume
                   mountPath: /etc/config
                 - name: keys

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -11,18 +11,20 @@ Logger:
 HTSGETStorage:
   Disabled: {{ .Values.htsget.disabled }}
   Protocol: {{ .Values.htsget.protocol }}
-  SendPublicKey: {{ .Values.htsget.sendpublickey }}
+  Timeout: 360s
 
 Server:
   # Require Bearer JWT authentication for the server APIs.
   # Server won't launch when configuration URL cannot be loaded.
   OidcAuth:
     # URL of the OIDC service configuration:
-    ServiceConfigUrl: {{ .Values.oidc.url }}
+    ServiceConfigURL: {{ .Values.oidc.url }}
     # Client ID and secret are sent with the token introspection request
     # (Basic authentication):
     ClientId: {{ .Values.oidc.clientid }}
     ClientSecret: {{ .Values.oidc.clientsecret }}
+    # This is irrelevant when only backend is deployed but needs be non-empty
+    RedirectURL: "http://localhost:8000/login"
     # Optional: if specified, this scope value must be in the token:
     # RequireScope:
     # Optional: if specified, this audience value must be in the token:
@@ -30,6 +32,7 @@ Server:
   BasicAuth:
     - User: {{ .Values.basicauth.user | quote }}
       Password: {{ .Values.basicauth.password | quote }}
+      Admin: true
 
   HostName: 0.0.0.0
 

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -61,7 +61,7 @@ Kubernetes:
           restartPolicy: Never
           securityContext:
             fsGroup: 1000
-            runAsUser: 1000
+            runAsUser: 65534
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -46,6 +46,8 @@ Kubernetes:
     apiVersion: batch/v1
     kind: Job
     metadata:
+      labels:
+        "kubernetes.io/job.executor": "true"
       ## DO NOT CHANGE NAME
       name: {{ print "{{.TaskId}}" }}
       namespace: {{ print "{{.Namespace}}" }}

--- a/charts/compute/files/funnel-server-config.yml
+++ b/charts/compute/files/funnel-server-config.yml
@@ -9,9 +9,12 @@ Logger:
   Level: {{ .Values.logLevel | quote }}
 
 HTSGETStorage:
-  Disabled: {{ .Values.htsget.disabled }}
-  Protocol: {{ .Values.htsget.protocol }}
-  Timeout: 360s
+  ServiceURL: {{ .Values.htsget.serviceURL | quote }}
+  Timeout: {{ .Values.htsget.timeout | quote }}
+
+SDAStorage:
+  ServiceURL: {{ .Values.sda.serviceURL | quote }}
+  Timeout: {{ .Values.sda.timeout | quote }}
 
 Server:
   # Require Bearer JWT authentication for the server APIs.

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -3,7 +3,7 @@ Database: boltdb
 Compute: {{ .Values.compute }}
 
 Logger:
-  Level: debug
+  Level: {{ .Values.logLevel | quote }}
 
 HTSGETStorage:
   Disabled: {{ .Values.htsget.disabled }}

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -27,6 +27,17 @@ Server:
   HostName: {{ .Release.Name }}
   RPCPort: 9090
 
+AmazonS3:
+  Disabled: {{ .Values.awsS3.disabled }}
+  Key: {{ .Values.awsS3.key | quote }}
+  Secret: {{ .Values.awsS3.secret | quote }}
+
+GenericS3:
+  - Disabled: {{ .Values.genericS3.disabled }}
+    Endpoint: {{ .Values.genericS3.endpoint | quote }}
+    Key: {{ .Values.genericS3.key | quote }}
+    Secret: {{ .Values.genericS3.secret | quote }}
+
 Kubernetes:
   # Change to "kubernetes" to use the kubernetes executor
   Executor: {{ .Values.compute }}

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -24,6 +24,12 @@ Server:
   HostName: {{ .Release.Name }}
   RPCPort: 9090
 
+LocalStorage : {
+  AllowedDirs : [
+    "/opt/funnel/funnel-work-dir",
+  ]
+}
+
 Kubernetes:
   # Change to "kubernetes" to use the kubernetes executor
   Executor: {{ .Values.compute }}

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -24,11 +24,10 @@ Server:
   HostName: {{ .Release.Name }}
   RPCPort: 9090
 
-
 Kubernetes:
   # Change to "kubernetes" to use the kubernetes executor
   Executor: {{ .Values.compute }}
-  Namespace: {{ .Release.Namespace }} 
+  Namespace: {{ .Release.Namespace }}
   ExecutorTemplate: |
     apiVersion: batch/v1
     kind: Job
@@ -37,7 +36,7 @@ Kubernetes:
       namespace: {{ print "{{.Namespace}}" }}
       labels:
         job-name: {{ print "{{.TaskId}}-{{.JobId}}" }}
-    spec: 
+    spec:
       backoffLimit: 0
       completions: 1
       template:
@@ -48,12 +47,12 @@ Kubernetes:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          containers: 
+          containers:
           - name: funnel-worker-{{ print "{{.TaskId}}" }}
             image: {{ print "{{.Image}}" }}
             imagePullPolicy: Always
             command: ["/bin/sh", "-c"]
-            args: {{.Command}}
+            args: {{ print "{{.Command}}" }}
             workingDir: {{ print "{{.Workdir}}" }}
             resources:
               requests:
@@ -74,12 +73,12 @@ Kubernetes:
               subPath: shared
             ### DO NOT CHANGE THIS
             {{ print "{{range $idx, $item := .Volumes}}" }}
-            - name: storage 
+            - name: storage
               mountPath: {{ print "{{$item.ContainerPath}}" }}
               subPath: {{ print "{{$.TaskId}}{{$item.ContainerPath}}" }}
             {{ print "{{end}}" }}
 
-          volumes: 
+          volumes:
           - name: storage
             persistentVolumeClaim:
               claimName: {{ .Values.pvc.name }}

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -41,12 +41,14 @@ Kubernetes:
       name: {{ print "{{.TaskId}}-{{.JobId}}" }}
       namespace: {{ print "{{.Namespace}}" }}
       labels:
-        kubernetes.io/job.executor: "true"
         job-name: {{ print "{{.TaskId}}-{{.JobId}}" }}
     spec:
       backoffLimit: 0
       completions: 1
       template:
+        metadata:
+          labels:
+            kubernetes.io/job.executor: "true"
         spec:
           restartPolicy: Never
           securityContext:

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -43,6 +43,7 @@ Kubernetes:
         spec:
           restartPolicy: Never
           securityContext:
+            fsGroup: 1000
             runAsUser: 1000
             runAsNonRoot: true
             seccompProfile:
@@ -67,6 +68,7 @@ Kubernetes:
               capabilities:
                 drop:
                   - ALL
+              privileged: false
             volumeMounts:
             - name: storage
               mountPath: /shared

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -43,9 +43,9 @@ Kubernetes:
         spec:
           restartPolicy: Never
           securityContext:
-            fsGroup: 65534
-            runAsUser: 65534
-            runAsGroup: 65534
+            fsGroup: {{ .Values.securityContext.worker.fsGroup}}
+            runAsUser: {{ .Values.securityContext.worker.runAsUser}}
+            runAsGroup: {{ .Values.securityContext.worker.runAsGroup}}
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -46,10 +46,10 @@ Kubernetes:
       backoffLimit: 0
       completions: 1
       template:
-        metadata:
-          labels:
-            kubernetes.io/job.executor: "true"
         spec:
+          metadata:
+            labels:
+              kubernetes.io/job.executor: "true"
           restartPolicy: Never
           securityContext:
             fsGroup: 1000

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -8,7 +8,7 @@ Logger:
 HTSGETStorage:
   Disabled: {{ .Values.htsget.disabled }}
   Protocol: {{ .Values.htsget.protocol }}
-  SendPublicKey: {{ .Values.htsget.sendpublickey }}
+  Timeout: 360s
 
 RPCClient:
   MaxRetries: 3

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -41,6 +41,7 @@ Kubernetes:
       name: {{ print "{{.TaskId}}-{{.JobId}}" }}
       namespace: {{ print "{{.Namespace}}" }}
       labels:
+        kubernetes.io/job.executor: "true"
         job-name: {{ print "{{.TaskId}}-{{.JobId}}" }}
     spec:
       backoffLimit: 0

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -62,8 +62,9 @@ Kubernetes:
                 memory: {{ print "{{if ne .RamGb 0.0 -}}{{printf \"%.0fG\" .RamGb}}{{else}}{{\"16M\"}}{{end}}" }}
                 ephemeral-storage: {{ print "{{if ne .DiskGb 0.0 -}}{{printf \"%.0fG\" .DiskGb}}{{else}}{{\"100M\"}}{{end}}" }}
               limits:
-                cpu: 1000m
-                memory: 5G
+                cpu: {{ .Values.computeResourceLimits.cpu | quote}}
+                memory: {{ .Values.computeResourceLimits.memory | quote }}
+                ephemeral-storage: {{ .Values.computeResourceLimits.ephemeralStorage | quote}}
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -62,9 +62,9 @@ Kubernetes:
                 memory: {{ print "{{if ne .RamGb 0.0 -}}{{printf \"%.0fG\" .RamGb}}{{else}}{{\"16M\"}}{{end}}" }}
                 ephemeral-storage: {{ print "{{if ne .DiskGb 0.0 -}}{{printf \"%.0fG\" .DiskGb}}{{else}}{{\"100M\"}}{{end}}" }}
               limits:
-                cpu: {{ .Values.computeResourceLimits.cpu | quote}}
-                memory: {{ .Values.computeResourceLimits.memory | quote }}
-                ephemeral-storage: {{ .Values.computeResourceLimits.ephemeralStorage | quote}}
+                cpu: {{ .Values.computeResourceLimits.worker.cpu | quote}}
+                memory: {{ .Values.computeResourceLimits.worker.memory | quote }}
+                ephemeral-storage: {{ .Values.computeResourceLimits.worker.ephemeralStorage | quote}}
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -24,12 +24,6 @@ Server:
   HostName: {{ .Release.Name }}
   RPCPort: 9090
 
-LocalStorage : {
-  AllowedDirs : [
-    "/opt/funnel/funnel-work-dir",
-  ]
-}
-
 Kubernetes:
   # Change to "kubernetes" to use the kubernetes executor
   Executor: {{ .Values.compute }}
@@ -49,8 +43,9 @@ Kubernetes:
         spec:
           restartPolicy: Never
           securityContext:
-            fsGroup: 1000
-            runAsUser: 1000
+            fsGroup: 65534
+            runAsUser: 65534
+            runAsGroup: 65534
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -6,9 +6,12 @@ Logger:
   Level: {{ .Values.logLevel | quote }}
 
 HTSGETStorage:
-  Disabled: {{ .Values.htsget.disabled }}
-  Protocol: {{ .Values.htsget.protocol }}
-  Timeout: 360s
+  ServiceURL: {{ .Values.htsget.serviceURL | quote }}
+  Timeout: {{ .Values.htsget.timeout | quote }}
+
+SDAStorage:
+  ServiceURL: {{ .Values.sda.serviceURL | quote }}
+  Timeout: {{ .Values.sda.timeout | quote }}
 
 RPCClient:
   MaxRetries: 3

--- a/charts/compute/files/funnel-worker-config.yml
+++ b/charts/compute/files/funnel-worker-config.yml
@@ -47,9 +47,6 @@ Kubernetes:
       completions: 1
       template:
         spec:
-          metadata:
-            labels:
-              kubernetes.io/job.executor: "true"
           restartPolicy: Never
           securityContext:
             fsGroup: 1000

--- a/charts/compute/templates/funnel-deployment.yaml
+++ b/charts/compute/templates/funnel-deployment.yaml
@@ -70,7 +70,7 @@ spec:
         - name: funnel-deployment-storage
           persistentVolumeClaim:
             claimName: {{ .Values.pvc.name }}
-        - secret:
+        - name: config-volume
+          secret:
             defaultMode: 420
             secretName: {{ .Release.Name }}-server-config
-          name: config-volume

--- a/charts/compute/templates/funnel-deployment.yaml
+++ b/charts/compute/templates/funnel-deployment.yaml
@@ -57,7 +57,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
 {{- end }}
-      serviceAccount: {{ .Values.funnel.serviceAccount }}
+      serviceAccount: {{ .Release.Name }}-sa
       volumes:
         - name: funnel-deployment-storage
           persistentVolumeClaim:

--- a/charts/compute/templates/funnel-deployment.yaml
+++ b/charts/compute/templates/funnel-deployment.yaml
@@ -43,12 +43,14 @@ spec:
             capabilities:
               drop:
                 - ALL
+            privileged: false
           volumeMounts:
             - mountPath: /opt/funnel/funnel-work-dir
               name: funnel-deployment-storage
             - mountPath: /etc/config
               name: config-volume
       securityContext:
+        fsGroup: 1000
         runAsNonRoot: true
         runAsUser: {{ .Values.funnel.runAsUser }}
 {{- if .Values.funnel.seccompProfile }}

--- a/charts/compute/templates/funnel-deployment.yaml
+++ b/charts/compute/templates/funnel-deployment.yaml
@@ -23,14 +23,11 @@ spec:
         app: {{ .Release.Name }}
     spec:
       containers:
-        - args:
-            - server
-            - run
-            - '--config'
-            - /etc/config/funnel-server-config.yml
+        - name: funnel
+          command: ["/app/funnel"]
+          args: ["server", "run", "--config", "/etc/config/funnel-server-config.yml"]
           image: {{ .Values.image }}
           imagePullPolicy: Always
-          name: funnel
           ports:
             - containerPort: 8000
               protocol: TCP

--- a/charts/compute/templates/funnel-deployment.yaml
+++ b/charts/compute/templates/funnel-deployment.yaml
@@ -49,12 +49,14 @@ spec:
               name: funnel-deployment-storage
             - mountPath: /etc/config
               name: config-volume
+  {{- if .Values.funnel.readinessProbeEnabled }}
           readinessProbe:
             httpGet:
               path: /health.html
               port: 8000
             initialDelaySeconds: 1
             periodSeconds: 5
+  {{- end }}
       securityContext:
         fsGroup: 1000
         runAsNonRoot: true

--- a/charts/compute/templates/funnel-deployment.yaml
+++ b/charts/compute/templates/funnel-deployment.yaml
@@ -49,6 +49,12 @@ spec:
               name: funnel-deployment-storage
             - mountPath: /etc/config
               name: config-volume
+          readinessProbe:
+            httpGet:
+              path: /health.html
+              port: 8000
+            initialDelaySeconds: 1
+            periodSeconds: 5
       securityContext:
         fsGroup: 1000
         runAsNonRoot: true

--- a/charts/compute/templates/funnel-deployment.yaml
+++ b/charts/compute/templates/funnel-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - containerPort: 9090
               protocol: TCP
           resources:
-            {{- toYaml $.Values.resources | nindent 12 }}
+            {{- toYaml $.Values.funnel.resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -55,12 +55,12 @@ spec:
         seccompProfile:
           type: RuntimeDefault
 {{- end }}
-      serviceAccount: {{ .Values.serviceAccount }}
+      serviceAccount: {{ .Values.funnel.serviceAccount }}
       volumes:
         - name: funnel-deployment-storage
           persistentVolumeClaim:
             claimName: {{ .Values.pvc.name }}
         - secret:
             defaultMode: 420
-            secretName: {{ .Release.Name }}-server-config 
+            secretName: {{ .Release.Name }}-server-config
           name: config-volume

--- a/charts/compute/templates/funnel-ingress.yaml
+++ b/charts/compute/templates/funnel-ingress.yaml
@@ -7,10 +7,12 @@ metadata:
     {{- toYaml $.Values.ingress.annotations | nindent 4 }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tlsEnabled }}
   tls:
    - hosts:
        - {{ .Values.ingress.host }}
      secretName: {{ .Values.ingress.host | replace "." "-" }}
+  {{- end }}
   rules:
   - host: {{ .Values.ingress.host }}
     http:

--- a/charts/compute/templates/funnel-rbac.yaml
+++ b/charts/compute/templates/funnel-rbac.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.createRole }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["batch", "extensions"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-rolebinding
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-sa
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/compute/templates/serviceaccount.yaml
+++ b/charts/compute/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.rbacEnabled }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-sa
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -45,9 +45,14 @@ funnel:
 
 # limit resources for master/worker containers
 computeResourceLimits:
-  cpu: 4
-  memory: 8G
-  ephemeralStorage: 10G
+  master:
+    cpu: 1
+    memory: 1G
+    ephemeralStorage: 10G
+  worker:
+    cpu: 8
+    memory: 8G
+    ephemeralStorage: 10G
 
 ingress:
   enabled: true

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -22,6 +22,18 @@ sda:
   serviceURL: http://download.local
   timeout: 360s
 
+# Enable and configure generic non-aws (ceph, minio etc) S3 storage
+genericS3:
+  disabled: true
+  endpoint: ""
+  key: ""
+  secret: ""
+
+# Enable and configure aws S3 storage
+awsS3:
+  disabled: true
+  key: ""
+  secret: ""
 basicauth:
   user: XXX
   password: XXX

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -2,15 +2,16 @@ oidc:
   url: https://login.elixir-czech.org/oidc/.well-known/openid-configuration
   clientid: XXXX
   clientsecret: XXXX
-  audience: snake123
+  audience: ""
 
 compute: kubernetes
 logLevel: info
 
+# storageClass needs to support ReadWriteMany
 pvc:
- name: storage
+ name: ""
  existing: false
- storageClass: nfs-csi
+ storageClass: ""
  size: 2Gi
 
 htsget:

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -5,6 +5,7 @@ oidc:
   audience: snake123
 
 compute: kubernetes
+logLevel: info
 
 pvc:
  name: storage

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -17,7 +17,6 @@ pvc:
 htsget:
   disabled: false
   protocol: https
-  sendpublickey: true
 
 basicauth:
   user: XXX
@@ -27,7 +26,7 @@ rpcclient:
   user: XXX
   password: XXX
 
-image: krkoo/funnel:2024-06-12
+image: ghcr.io/mrtamm/funnel-gdi:latest
 
 funnel:
   resources:

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -43,6 +43,12 @@ funnel:
   # for debugging purposes
   readinessProbeEnabled: true
 
+# limit resources for master/worker containers
+computeResourceLimits:
+  cpu: 4
+  memory: 8G
+  ephemeralStorage: 10G
+
 ingress:
   enabled: true
   className: nginx

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -41,6 +41,8 @@ funnel:
       ephemeral-storage: 25Gi
   runAsUser: 1000
   seccompProfile: true
+  # for debugging purposes
+  readinessProbeEnabled: true
 
 ingress:
   enabled: true

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -39,14 +39,17 @@ funnel:
       cpu: 100m
       memory: 4Gi
       ephemeral-storage: 25Gi
-  serviceAccount: funnel-sa
   runAsUser: 1000
   seccompProfile: true
 
 ingress:
   enabled: true
   className: nginx
-  annotations:
-    kubernetes.io/tls-acme: "true"
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+  annotations: {}
+    # kubernetes.io/tls-acme: "true"
+    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
   host: SOME_HOST
+
+# if false, a ServiceAccount needs to be created with name .Release.Name-sa
+rbacEnabled: true
+createRole: true

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -51,6 +51,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
     # cert-manager.io/cluster-issuer: "letsencrypt-prod"
   host: SOME_HOST
+  tlsEnabled: true # Set to false only for testing
 
 # if false, a ServiceAccount needs to be created with name .Release.Name-sa
 rbacEnabled: true

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -54,6 +54,15 @@ computeResourceLimits:
     memory: 8G
     ephemeralStorage: 10G
 
+securityContext:
+  master:
+    fsGroup: 1000
+    runAsUser: 1000
+  worker:
+    fsGroup: 1000
+    runAsUser: 1000
+    runAsGroup: 1000
+
 ingress:
   enabled: true
   className: nginx

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -15,8 +15,12 @@ pvc:
  size: 2Gi
 
 htsget:
-  disabled: false
-  protocol: https
+  serviceURL: http://htsget.local
+  timeout: 360s
+
+sda:
+  serviceURL: http://download.local
+  timeout: 360s
 
 basicauth:
   user: XXX
@@ -36,9 +40,9 @@ funnel:
       ephemeral-storage: 25Gi
     requests:
       cpu: 100m
-      memory: 4Gi
+      memory: 2Gi
       ephemeral-storage: 25Gi
-  runAsUser: 65534
+  runAsUser: 1000
   seccompProfile: true
   # for debugging purposes
   readinessProbeEnabled: true

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -39,7 +39,7 @@ funnel:
       cpu: 100m
       memory: 4Gi
       ephemeral-storage: 25Gi
-  runAsUser: 1000
+  runAsUser: 65534
   seccompProfile: true
   # for debugging purposes
   readinessProbeEnabled: true


### PR DESCRIPTION
This PR updates the CC Helm charts with changes that were brought about during deployment work in the GDI cluster of the Swedish node.

Main changes summarized below:
- small fixes in order to make the charts working
- sane defaults for dependency resources (e.g. rbac etc) were added and can be enabled from the values file
- changes for the latest gdi-funnel image to deploy

Chart versions and image versions:
- Chart versions up to 0.6.2 use the old image `krkoo/funnel:2024-06-12` 
- version 0.7.0 uses the latest: `ghcr.io/mrtamm/funnel-gdi:latest`
- versions >=0.8.0 use image `ghcr.io/mrtamm/funnel-gdi:2024-11-12` (which has the sda backend implemented)


We have a chart releaser installed in our [fork repo at NBIS](https://github.com/NBISweden/Containerized-Compute-Helm-Charts/tree/compute-charts) and all releases can be pulled with:
```
helm repo add gdi-compute https://nbisweden.github.io/Containerized-Compute-Helm-Charts
```

Any comments welcome!

P.S. Latest batch of changes reflect the setup that deployed in SE where the pipeline for MS8 was run.
